### PR TITLE
Add Instructions To Install nightly Toolchain

### DIFF
--- a/cli/liblisa-semantics-tool/README.md
+++ b/cli/liblisa-semantics-tool/README.md
@@ -5,6 +5,7 @@ It requires the raw semantics that can be downloaded from [here](https://osf.io/
 ## Installation
 Through [`cargo`](https://rustup.rs):
 ```
+rustup toolchain install nightly # if you don't have it
 cargo +nightly install liblisa-semantics-tool
 ```
 


### PR DESCRIPTION
I was getting the error 'error: toolchain 'nightly-x86_64-unknown-linux-gnu' is not installed'

The `rustup toolchain install nightly` command fixed it. Hopefully this saves others some time.